### PR TITLE
Feat: Restaurar header y agregar modo oscuro e i18n

### DIFF
--- a/docs/i18n/en_US.json
+++ b/docs/i18n/en_US.json
@@ -139,5 +139,7 @@
     "conditionsSec9Text": "We reserve the right to review and update these Terms and Conditions at any time. Modifications will be communicated oportunely through our official channels. We recommend reviewing this section periodically to stay informed of changes. Continued use of our services after any modification will constitute acceptance of such changes.",
     "conditionsSec10Title": "10. Contact",
     "conditionsSec10Text": "If you have any questions, comments, or requirements related to these terms, you can contact us via email at support@parkingnow.com. You can also visit our administrative offices located at Av. Innovación 123, Lima, Peru.",
-    "conditionsLastUpdated": "Last updated: June 18, 2025"
+    "conditionsLastUpdated": "Last updated: June 18, 2025",
+    "languageEn": "EN",
+    "languageEs": "ES"
 }

--- a/docs/i18n/es_419.json
+++ b/docs/i18n/es_419.json
@@ -139,5 +139,7 @@
     "conditionsSec9Text": "Nos reservamos el derecho de revisar y actualizar estos Términos y Condiciones en cualquier momento. Las modificaciones serán comunicadas oportunamente a través de nuestros canales oficiales. Recomendamos revisar esta sección periódicamente para estar al tanto de los cambios. El uso continuo de nuestros servicios después de cualquier modificación constituirá aceptación de dichos cambios.",
     "conditionsSec10Title": "10. Contacto",
     "conditionsSec10Text": "Si tienes alguna consulta, comentario o requerimiento relacionado con estos términos, puedes contactarnos mediante correo electrónico a soporte@parkingnow.com. También puedes visitar nuestras oficinas administrativas ubicadas en Av. Innovación 123, Lima, Perú.",
-    "conditionsLastUpdated": "Última actualización: 18 de junio de 2025"
+    "conditionsLastUpdated": "Última actualización: 18 de junio de 2025",
+    "languageEn": "EN",
+    "languageEs": "ES"
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,6 +21,28 @@
 
 <body>
 
+<!-- Header Section -->
+<header class="center-align" style="padding: 20px 0; background-color: var(--hero-bg-color); display: flex; justify-content: center; align-items: center; position: relative;">
+    <h1 style="font-family: 'Kalam', cursive; color: var(--hero-accent-color); margin: 0; font-size: 3rem; text-align: center; flex-grow: 1;" data-i18n="appName">PARKINGNOW</h1>
+    <div style="position: absolute; right: 20px; display: flex; align-items: center;">
+        <!-- Dark Mode Toggle Switch -->
+        <div class="switch" style="margin-right: 15px;">
+            <label style="color: var(--hero-text-color);" aria-label="Toggle dark mode">
+                <span data-i18n="darkMode" style="margin-right: 5px;">Modo Oscuro</span>
+                <input type="checkbox" id="headerDarkModeToggle">
+                <span class="lever"></span>
+            </label>
+        </div>
+        <!-- Language Selector -->
+        <div style="margin-left: 15px;">
+            <select id="headerLanguageSelector" class="browser-default" style="background-color: var(--hero-bg-color); color: var(--hero-text-color); border: 1px solid var(--hero-text-color); border-radius: 4px; padding: 5px;" aria-label="Select language">
+                <option value="en_US" data-i18n="languageEn">EN</option>
+                <option value="es_419" data-i18n="languageEs">ES</option>
+            </select>
+        </div>
+    </div>
+</header>
+
 <!-- Floating Chat Button -->
 <button id="chatButton" class="btn-floating btn-large waves-effect waves-light yellow darken-1" aria-label="Open platform chat">
     <i class="material-icons">P</i>

--- a/docs/js/script.js
+++ b/docs/js/script.js
@@ -140,6 +140,36 @@ document.addEventListener("DOMContentLoaded", () => {
     // Load initial language
     loadLanguage(currentLanguage);
 
+    // Language selector in the header
+    const headerLanguageSelector = document.getElementById('headerLanguageSelector');
+    if (headerLanguageSelector) {
+        headerLanguageSelector.value = currentLanguage; // Set initial value based on loaded language
+        headerLanguageSelector.addEventListener('change', (event) => {
+            currentLanguage = event.target.value;
+            loadLanguage(currentLanguage);
+            // If navbar language switcher exists, update its text (optional, as loadLanguage handles main button)
+             if (languageSwitcherButton) {
+                if (currentLanguage === "en_US") {
+                    languageSwitcherButton.textContent = "Español (Latinoamérica)";
+                } else {
+                    languageSwitcherButton.textContent = "English (US)";
+                }
+            }
+        });
+    }
+
+    // Update header selector when navbar button is clicked
+    if (languageSwitcherButton && headerLanguageSelector) {
+        const observer = new MutationObserver(() => {
+            // currentLanguage is updated by the loadLanguage function called by the button
+            if (headerLanguageSelector.value !== currentLanguage) {
+                headerLanguageSelector.value = currentLanguage;
+            }
+        });
+        observer.observe(languageSwitcherButton, { childList: true, characterData: true, subtree: true });
+    }
+
+
     // Dark Mode Toggle Functionality
     const darkModeToggle = document.getElementById('darkModeToggle');
     const body = document.body;
@@ -166,16 +196,29 @@ document.addEventListener("DOMContentLoaded", () => {
     applyTheme(savedTheme);
     currentLanguage = localStorage.getItem("language") || "en_US"; // Ensure currentLanguage is also loaded
 
-    // Event listener for the toggle
+    // Event listener for the navbar toggle
     if (darkModeToggle) {
         darkModeToggle.addEventListener('change', () => {
-            if (darkModeToggle.checked) {
-                applyTheme('dark');
-                localStorage.setItem('theme', 'dark');
-            } else {
-                applyTheme('light');
-                localStorage.setItem('theme', 'light');
-            }
+            const newTheme = darkModeToggle.checked ? 'dark' : 'light';
+            applyTheme(newTheme);
+            localStorage.setItem('theme', newTheme);
+            // Sync header toggle if it exists
+            if (headerDarkModeToggle) headerDarkModeToggle.checked = darkModeToggle.checked;
+        });
+    }
+
+    // Event listener for the header toggle
+    const headerDarkModeToggle = document.getElementById('headerDarkModeToggle');
+    if (headerDarkModeToggle) {
+        // Sync with navbar toggle initial state
+        if (darkModeToggle) headerDarkModeToggle.checked = darkModeToggle.checked;
+
+        headerDarkModeToggle.addEventListener('change', () => {
+            const newTheme = headerDarkModeToggle.checked ? 'dark' : 'light';
+            applyTheme(newTheme);
+            localStorage.setItem('theme', newTheme);
+            // Sync navbar toggle if it exists
+            if (darkModeToggle) darkModeToggle.checked = headerDarkModeToggle.checked;
         });
     }
 });


### PR DESCRIPTION
- Se restaura el header original con el título 'PARKINGNOW'.
- Se agrega un interruptor de modo claro/oscuro en el header con etiqueta de texto. La preferencia se guarda en localStorage y se sincroniza con el interruptor existente en el navbar.
- Se agrega un selector de idioma (EN/ES) en el header usando un <select>. La preferencia se guarda en localStorage y se sincroniza con el botón de idioma existente en el navbar.
- Se actualizan los scripts y estilos para la nueva funcionalidad, asegurando accesibilidad y consistencia visual.